### PR TITLE
Show loader when first page is inverted by setting it transparant on …

### DIFF
--- a/app/assets/stylesheets/pageflow/themes/scrollytelling/standards.css.scss
+++ b/app/assets/stylesheets/pageflow/themes/scrollytelling/standards.css.scss
@@ -171,7 +171,7 @@ ul.options {
 }
 
 // Set initial state of hidden
-.page.invert, .page.invert.text_position_right {
+.entry .page.invert, .entry .page.invert.text_position_right {
     background-color:transparent;
 }
 


### PR DESCRIPTION
…load 

Volkskrant thema (doder dan dood) laat de lader nog niet zien. Ik heb de background tijdens het laden overschreven via het ScrollyTelling thema.. Dit kan dus ook mogelijk effect hebben op andere thema's.  
