### PR TITLE
upgrade Pageflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'coffee-rails'
 gem 'jquery-rails'
 
 # gems we need
-gem 'pageflow', '~> 12.0.1'
+gem 'pageflow', '~> 12.1.0'
 gem 'state_machine', git: 'https://github.com/codevise/state_machine.git'
 gem 'postmark-rails'
 gem 'rack-attack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,10 @@ GEM
       ransack (~> 1.3)
       sass-rails
       sprockets (< 4)
+    activeadmin-searchable_select (1.0.0)
+      activeadmin (~> 1.x)
+      jquery-rails (>= 3.0, < 5)
+      select2-rails (~> 4.0)
     activejob (4.2.10)
       activesupport (= 4.2.10)
       globalid (>= 0.3.0)
@@ -204,7 +208,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_mime (0.1.4)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     mono_logger (1.1.0)
@@ -216,8 +220,9 @@ GEM
       mini_portile2 (~> 2.3.0)
     okcomputer (1.17.0)
     orm_adapter (0.5.0)
-    pageflow (12.0.4)
+    pageflow (12.1.0)
       activeadmin (= 1.0.0.pre4)
+      activeadmin-searchable_select (~> 1.0)
       ar_after_transaction (~> 0.4.0)
       aws-sdk (~> 1.60)
       backbone-rails (~> 1.0.0)
@@ -352,8 +357,8 @@ GEM
     redis-activesupport (5.0.4)
       activesupport (>= 3, < 6)
       redis-store (>= 1.3, < 2)
-    redis-namespace (1.5.3)
-      redis (~> 3.0, >= 3.0.4)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     redis-rack (2.0.3)
       rack (>= 1.5, < 3)
       redis-store (>= 1.2, < 2)
@@ -422,6 +427,8 @@ GEM
     scrollytelling-navigation (12.0.2)
       pageflow (~> 12.x)
       rails (>= 3.0, < 5.0)
+    select2-rails (4.0.3)
+      thor (~> 0.14)
     selenium-webdriver (3.6.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -466,7 +473,7 @@ GEM
       railties (>= 3.1.0)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yajl-ruby (1.3.0)
+    yajl-ruby (1.3.1)
     zencoder (2.5.1)
       multi_json
     zxcvbn-js (4.4.3)
@@ -485,7 +492,7 @@ DEPENDENCIES
   jquery-rails
   mysql2
   okcomputer
-  pageflow (~> 12.0.1)
+  pageflow (~> 12.1.0)
   pageflow-before-after
   pageflow-chart
   pageflow-embedded-video
@@ -514,4 +521,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -2,7 +2,7 @@
 
 # Version of your assets, change this if you want to expire all your assets.
 # When updating Pageflow, update this as well. It will force a refresh for i18n-js.
-Rails.application.config.assets.version = '35'
+Rails.application.config.assets.version = '36'
 
 # Add additional assets to the asset load path
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/db/migrate/20171112094726_add_configuration_to_widgets.pageflow.rb
+++ b/db/migrate/20171112094726_add_configuration_to_widgets.pageflow.rb
@@ -1,0 +1,6 @@
+# This migration comes from pageflow (originally 20170201074328)
+class AddConfigurationToWidgets < ActiveRecord::Migration
+  def change
+    add_column :pageflow_widgets, :configuration, :text
+  end
+end

--- a/db/migrate/20171112094727_add_theme_name_to_revisions.pageflow.rb
+++ b/db/migrate/20171112094727_add_theme_name_to_revisions.pageflow.rb
@@ -1,0 +1,13 @@
+# This migration comes from pageflow (originally 20170315130000)
+class AddThemeNameToRevisions < ActiveRecord::Migration
+  def change
+    add_column :pageflow_revisions, :theme_name, :string, null: false, default: 'default'
+
+    execute(<<-SQL)
+      UPDATE pageflow_revisions, pageflow_entries, pageflow_themings
+      SET pageflow_revisions.theme_name = pageflow_themings.theme_name
+      WHERE pageflow_revisions.entry_id = pageflow_entries.id
+      AND pageflow_entries.theming_id = pageflow_themings.id
+    SQL
+  end
+end

--- a/db/migrate/20171112094728_reset_copied_snapshot_type.pageflow.rb
+++ b/db/migrate/20171112094728_reset_copied_snapshot_type.pageflow.rb
@@ -1,0 +1,25 @@
+# This migration comes from pageflow (originally 20170912165050)
+class ResetCopiedSnapshotType < ActiveRecord::Migration
+  def up
+    fix_restored_drafts
+    fix_publications_created_from_restored_drafts
+  end
+
+  private
+
+  def fix_restored_drafts
+    execute(<<-SQL)
+      UPDATE pageflow_revisions
+        SET snapshot_type = NULL
+        WHERE frozen_at IS NULL;
+    SQL
+  end
+
+  def fix_publications_created_from_restored_drafts
+    execute(<<-SQL)
+      UPDATE pageflow_revisions
+        SET snapshot_type = NULL
+        WHERE published_at IS NOT NULL;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171030161913) do
+ActiveRecord::Schema.define(version: 20171112094728) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 191
@@ -255,16 +255,16 @@ ActiveRecord::Schema.define(version: 20171030161913) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "credits",                     limit: 65535
-    t.string   "title",                       limit: 191,   default: "",    null: false
+    t.string   "title",                       limit: 191,   default: "",        null: false
     t.text     "summary",                     limit: 65535
     t.boolean  "manual_start",                              default: false
     t.integer  "restored_from_id",            limit: 4
     t.datetime "frozen_at"
     t.string   "snapshot_type",               limit: 191
-    t.string   "home_url",                    limit: 191,   default: "",    null: false
-    t.boolean  "home_button_enabled",                       default: false, null: false
-    t.boolean  "emphasize_chapter_beginning",               default: false, null: false
-    t.boolean  "emphasize_new_pages",                       default: false, null: false
+    t.string   "home_url",                    limit: 191,   default: "",        null: false
+    t.boolean  "home_button_enabled",                       default: false,     null: false
+    t.boolean  "emphasize_chapter_beginning",               default: false,     null: false
+    t.boolean  "emphasize_new_pages",                       default: false,     null: false
     t.integer  "share_image_id",              limit: 4
     t.integer  "share_image_x",               limit: 4
     t.integer  "share_image_y",               limit: 4
@@ -273,8 +273,9 @@ ActiveRecord::Schema.define(version: 20171030161913) do
     t.string   "author",                      limit: 191
     t.string   "publisher",                   limit: 191
     t.string   "keywords",                    limit: 191
-    t.boolean  "overview_button_enabled",                   default: true,  null: false
-    t.string   "share_url",                   limit: 255,   default: "",    null: false
+    t.boolean  "overview_button_enabled",                   default: true,      null: false
+    t.string   "share_url",                   limit: 255,   default: "",        null: false
+    t.string   "theme_name",                  limit: 255,   default: "default", null: false
   end
 
   add_index "pageflow_revisions", ["entry_id", "published_at", "published_until"], name: "index_pageflow_revisions_on_publication_timestamps", using: :btree
@@ -374,12 +375,13 @@ ActiveRecord::Schema.define(version: 20171030161913) do
   add_index "pageflow_video_files", ["parent_file_id", "parent_file_model_type"], name: "index_video_files_on_parent_id_and_parent_model_type", using: :btree
 
   create_table "pageflow_widgets", force: :cascade do |t|
-    t.integer  "subject_id",   limit: 4
-    t.string   "subject_type", limit: 191
-    t.string   "type_name",    limit: 191
-    t.string   "role",         limit: 191
+    t.integer  "subject_id",    limit: 4
+    t.string   "subject_type",  limit: 191
+    t.string   "type_name",     limit: 191
+    t.string   "role",          limit: 191
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "configuration", limit: 65535
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
2017-11-07

[Compare changes](https://github.com/codevise/pageflow/compare/12-0-stable...v12.1.0)

- Include HLS in output presences of legacy files
  ([#872](https://github.com/codevise/pageflow/pull/872),
   [#867](https://github.com/codevise/pageflow/pull/867))

  The database migration for Pageflow 12.0 which updates output
  presences of existing video files is missing the HLS variant. This
  causes HLS urls of existing video files to be rendered as
  `undefined`.

  To apply the fix, install migrations and migrate your database. This
  fix has previously been released as part of version 12.0.2.

- Add Resque::Server to the generated routes
  ([#871](https://github.com/codevise/pageflow/pull/871))

  Mounting the Resque web server makes it easier to inspect background
  workers and restart jobs that have failed. See the issue description
  of [#856](https://github.com/codevise/pageflow/issues/856) on how to
  add this to existing apps.

- The theme configured on account level now only acts as a default for
  new entries. After enabling the `selectable_themes` feature, a theme
  selection dialog is available inside the editor from the "Title and
  Options > Appearance" tab. The dialog allows configuring the theme
  on a per revision basis.
  ([#781](https://github.com/codevise/pageflow/pull/781),
   [#897](https://github.com/codevise/pageflow/pull/897))

- Use page from url hash es landing page
  ([#832](https://github.com/codevise/pageflow/pull/832))
- Do not record history when changing pages via scrolling
  ([#831](https://github.com/codevise/pageflow/pull/831))
- Improve text tracks and info box display logic
  ([#826](https://github.com/codevise/pageflow/pull/826))
- Bug fix: Fix order of public i18n fallback
  ([#883](https://github.com/codevise/pageflow/pull/883))
- Bug fix: Prevent display of NaN duration in video controls
  ([#878](https://github.com/codevise/pageflow/pull/878))
- Bug fix: Prevent 404 when share image has been deleted
  ([#816](https://github.com/codevise/pageflow/pull/816))

- Use searchable select boxes in admin forms
  ([#888](https://github.com/codevise/pageflow/pull/888))
- Remove sensitive data from active admin downloads
  ([#899](https://github.com/codevise/pageflow/pull/899))
- Add config option to prevent multi account users
  ([#848](https://github.com/codevise/pageflow/pull/848),
   [#868](https://github.com/codevise/pageflow/pull/868))
- Add config options to restrict account manager permissions
  ([#849](https://github.com/codevise/pageflow/pull/849))
- Fix N+1 query in account admin users tab
  ([#877](https://github.com/codevise/pageflow/pull/877))
- Bug fix: Hide restore link and snapshot button for entry previewers
  ([#853](https://github.com/codevise/pageflow/pull/853))
- Bug fix: Use copy of current_user in profile form
  ([#850](https://github.com/codevise/pageflow/pull/850))
- Bug fix: Ensure new entry button is hidden for editors
  ([#847](https://github.com/codevise/pageflow/pull/847))
- Bug fix: Show folder edit button only for publishers and above
  ([#838](https://github.com/codevise/pageflow/pull/838))
- Bug fix: Allow :create entry only for publishers on accounts, not on entries
  ([#836](https://github.com/codevise/pageflow/pull/836))

- Widget configuration
  ([#694](https://github.com/codevise/pageflow/pull/694),
   [#809](https://github.com/codevise/pageflow/pull/809))
- Bug fix: Ensure page order in editor preview stays up to date
  ([#898](https://github.com/codevise/pageflow/pull/898))
- Bug fix: Switch off file meta data edit links when uploading
  ([#857](https://github.com/codevise/pageflow/pull/857))
- Bug fix: Improve polling for HostedFile state
  ([#822](https://github.com/codevise/pageflow/pull/822))
- Bug fix: Handle undefined page title.
  ([#763](https://github.com/codevise/pageflow/pull/763))

- Use relative urls inside dash and hls playlists
  ([#842](https://github.com/codevise/pageflow/pull/842))
- Use web audio api for volume fading if available
  ([#800](https://github.com/codevise/pageflow/pull/800),
   [#863](https://github.com/codevise/pageflow/pull/863))

- Add panorama_mask image file style
  ([#830](https://github.com/codevise/pageflow/pull/830))
- Bug fix: Make url template generation more robust
  ([#876](https://github.com/codevise/pageflow/pull/876))

- Themes can now be guarded by feature flags
  ([#765](https://github.com/codevise/pageflow/pull/765))
- Extend EncodingConfirmation by public account attribute
  ([#817](https://github.com/codevise/pageflow/pull/817))
- Extend query interface
  ([#815](https://github.com/codevise/pageflow/pull/815))
- Accept options for accounts admin menu via config
  ([#811](https://github.com/codevise/pageflow/pull/811))
- Add placeholder options to textareainputview
  ([#807](https://github.com/codevise/pageflow/pull/807))
- Call hook on entry publication
  ([#806](https://github.com/codevise/pageflow/pull/806))
- Add rake task and resque job to delete old auto snapshots
  ([#861](https://github.com/codevise/pageflow/pull/861),
   [#882](https://github.com/codevise/pageflow/pull/882))
- Generate a secure password in the seeds
  ([#775](https://github.com/codevise/pageflow/pull/775))

- Allow specifying opacity of image variant logo
  ([#799](https://github.com/codevise/pageflow/pull/799))
- Allow setting size of custom loading spinner background
  ([#798](https://github.com/codevise/pageflow/pull/798))
- Add theme option to right align logo in desktop layout
  ([#797](https://github.com/codevise/pageflow/pull/797))
- Add theme option to hide scroll indicator
  ([#790](https://github.com/codevise/pageflow/pull/790))
- Make content text max width configurable
  ([#780](https://github.com/codevise/pageflow/pull/780),
   [#804](https://github.com/codevise/pageflow/pull/804))

- Import nginx-upload-module guide from wiki
  ([#814](https://github.com/codevise/pageflow/pull/814),
   [#821](https://github.com/codevise/pageflow/pull/821))
- Add documentation for versioning policy
  ([#866](https://github.com/codevise/pageflow/pull/866))
- Fix small typos
  ([#787](https://github.com/codevise/pageflow/pull/787))

- Precompile assets in Travis run
  ([#873](https://github.com/codevise/pageflow/pull/873))
- Test workflow improvements
  ([#803](https://github.com/codevise/pageflow/pull/803))
- Generate admins with account membership in specs
  ([#840](https://github.com/codevise/pageflow/pull/840))
- Use rails 4.2.9 in tests
  ([#837](https://github.com/codevise/pageflow/pull/837))
- Clean up memberships admin code
  ([#835](https://github.com/codevise/pageflow/pull/835))
- Basic tests for UsersTab add user button
  ([#805](https://github.com/codevise/pageflow/pull/805))
- Use codevise/teaspoon for logging backtraces on console
  ([#786](https://github.com/codevise/pageflow/pull/786))
- Split vendored code from our own
  ([#885](https://github.com/codevise/pageflow/pull/885))
- Introduce ApplicationRecord
  ([#889](https://github.com/codevise/pageflow/pull/889))
- Move configuration into a concern
  ([#794](https://github.com/codevise/pageflow/pull/794))
- Read the attribute instead of super
  ([#810](https://github.com/codevise/pageflow/pull/810))
- Destroy widgets when parent subject is destroyed
  ([#834](https://github.com/codevise/pageflow/pull/834))
- Fix dummy app generation on Travis for Rubygems 2.7
  ([#893](https://github.com/codevise/pageflow/pull/893))
- Update contents of gemspec
  ([#891](https://github.com/codevise/pageflow/pull/891))
- Bug fix: Work around breaking change in resque_mailer 2.4.3
  ([#894](https://github.com/codevise/pageflow/pull/894))

See
[12-0-stable](https://github.com/codevise/pageflow/blob/12-0-stable/CHANGELOG.md)
branch for previous changes.